### PR TITLE
RND-2232: imx93_var_som: lpddr4x_timing: update base lpddr4 timings

### DIFF
--- a/board/variscite/imx93_var_som/lpddr4x_timing.c
+++ b/board/variscite/imx93_var_som/lpddr4x_timing.c
@@ -1,16 +1,17 @@
 /*
- * Copyright 2023 NXP
+ * Copyright 2024 NXP
  *
- * SPDX-License-Identifier: GPL-2.0+
+ * SPDX-License-Identifier: BSD-3-Clause
  *
- * Code generated with DDR Tool v2.0.0_6.4.
+ * Code generated with DDR Tool v3.4.0_8.3-e3369a1a.
+ * DDR PHY FW2022.01
  */
 
 #include <linux/kernel.h>
 #include <asm/arch/ddr.h>
 
-struct dram_cfg_param ddr_ddrc_cfg[] = {
-	/** Initialize DDRC registers **/
+/* Initialize DDRC registers */
+static struct dram_cfg_param ddr_ddrc_cfg[] = {
 	{0x4e300110, 0x44100001},
 	{0x4e300000, 0x8000ff},
 	{0x4e300008, 0x0},
@@ -30,7 +31,6 @@ struct dram_cfg_param ddr_ddrc_cfg[] = {
 	{0x4e301254, 0x0},
 	{0x4e301258, 0x0},
 	{0x4e30125c, 0x0},
-
 };
 
 /* dram fsp cfg */
@@ -40,8 +40,8 @@ static struct dram_fsp_cfg ddr_dram_fsp_cfg[] = {
 			{0x4e300100, 0x24AB321B},
 			{0x4e300104, 0xF8EE001B},
 			{0x4e300108, 0x2F2EE233},
-			{0x4e30010C, 0x0005C18B},
-			{0x4e300124, 0x1C790000},
+			{0x4e30010C, 0x0005E18B},
+			{0x4e300124, 0x1C760000},
 			{0x4e300160, 0x00009102},
 			{0x4e30016C, 0x35F00000},
 			{0x4e300170, 0x8B0B0608},
@@ -51,7 +51,7 @@ static struct dram_fsp_cfg ddr_dram_fsp_cfg[] = {
 			{0x4e30025C, 0x00000400},
 			{0x4e300300, 0x224F2213},
 			{0x4e300304, 0x015B2213},
-			{0x4e300308, 0x0A380E3D},
+			{0x4e300308, 0x0A3C0E3D},
 		},
 		{
 			{0x01, 0xE4},
@@ -120,7 +120,7 @@ static struct dram_fsp_cfg ddr_dram_fsp_cfg[] = {
 };
 
 /* PHY Initialize Configuration */
-struct dram_cfg_param ddr_ddrphy_cfg[] = {
+static struct dram_cfg_param ddr_ddrphy_cfg[] = {
 	{0x100a0, 0x4},
 	{0x100a1, 0x5},
 	{0x100a2, 0x6},
@@ -252,12 +252,10 @@ struct dram_cfg_param ddr_ddrphy_cfg[] = {
 	{0x1200c7, 0x21},
 	{0x200ca, 0x24},
 	{0x1200ca, 0x24},
-
 };
 
-
-/* ddr phy trained csr */
-struct dram_cfg_param ddr_ddrphy_trained_csr[] = {
+/* PHY trained csr */
+static struct dram_cfg_param ddr_ddrphy_trained_csr[] = {
 	{0x1005f, 0x0},
 	{0x1015f, 0x0},
 	{0x1105f, 0x0},
@@ -1234,11 +1232,10 @@ struct dram_cfg_param ddr_ddrphy_trained_csr[] = {
 	{0x11640, 0x0},
 	{0x11740, 0x0},
 	{0x11840, 0x0},
-
 };
 
 /* P0 message block parameter for training firmware */
-struct dram_cfg_param ddr_fsp0_cfg[] = {
+static struct dram_cfg_param ddr_fsp0_cfg[] = {
 	{0xd0000, 0x0},
 	{0x54003, 0xe94},
 	{0x54004, 0x4},
@@ -1273,8 +1270,9 @@ struct dram_cfg_param ddr_fsp0_cfg[] = {
 	{0x5403d, 0x400},
 	{0xd0000, 0x1}
 };
+
 /* P1 message block parameter for training firmware */
-struct dram_cfg_param ddr_fsp1_cfg[] = {
+static struct dram_cfg_param ddr_fsp1_cfg[] = {
 	{0xd0000, 0x0},
 	{0x54002, 0x1},
 	{0x54003, 0x74a},
@@ -1310,8 +1308,9 @@ struct dram_cfg_param ddr_fsp1_cfg[] = {
 	{0x5403d, 0x400},
 	{0xd0000, 0x1}
 };
+
 /* P2 message block parameter for training firmware */
-struct dram_cfg_param ddr_fsp2_cfg[] = {
+static struct dram_cfg_param ddr_fsp2_cfg[] = {
 	{0xd0000, 0x0},
 	{0x54002, 0x102},
 	{0x54003, 0x270},
@@ -1349,9 +1348,8 @@ struct dram_cfg_param ddr_fsp2_cfg[] = {
 };
 
 
-
 /* P0 2D message block parameter for training firmware */
-struct dram_cfg_param ddr_fsp0_2d_cfg[] = {
+static struct dram_cfg_param ddr_fsp0_2d_cfg[] = {
 	{0xd0000, 0x0},
 	{0x54003, 0xe94},
 	{0x54004, 0x4},
@@ -1388,9 +1386,8 @@ struct dram_cfg_param ddr_fsp0_2d_cfg[] = {
 	{0xd0000, 0x1}
 };
 
-
 /* DRAM PHY init engine image */
-struct dram_cfg_param ddr_phy_pie[] = {
+static struct dram_cfg_param ddr_phy_pie[] = {
 	{0xd0000, 0x0},
 	{0x90000, 0x10},
 	{0x90001, 0x400},
@@ -1950,18 +1947,15 @@ struct dram_cfg_param ddr_phy_pie[] = {
 	{0x20088, 0x19},
 	{0xc0080, 0x0},
 	{0xd0000, 0x1},
-
 };
 
-
-struct dram_fsp_msg ddr_dram_fsp_msg[] = {
+static struct dram_fsp_msg ddr_dram_fsp_msg[] = {
 	{
 		/* P0 3733mts 1D */
 		.drate = 3733,
 		.fw_type = FW_1D_IMAGE,
 		.fsp_cfg = ddr_fsp0_cfg,
 		.fsp_cfg_num = ARRAY_SIZE(ddr_fsp0_cfg),
-
 	},
 	{
 		/* P1 1866mts 1D */
@@ -1969,7 +1963,6 @@ struct dram_fsp_msg ddr_dram_fsp_msg[] = {
 		.fw_type = FW_1D_IMAGE,
 		.fsp_cfg = ddr_fsp1_cfg,
 		.fsp_cfg_num = ARRAY_SIZE(ddr_fsp1_cfg),
-
 	},
 	{
 		/* P2 625mts 1D */
@@ -1977,9 +1970,7 @@ struct dram_fsp_msg ddr_dram_fsp_msg[] = {
 		.fw_type = FW_1D_IMAGE,
 		.fsp_cfg = ddr_fsp2_cfg,
 		.fsp_cfg_num = ARRAY_SIZE(ddr_fsp2_cfg),
-
 	},
-
 	{
 		/* P0 3733mts 2D */
 		.drate = 3733,
@@ -1987,9 +1978,7 @@ struct dram_fsp_msg ddr_dram_fsp_msg[] = {
 		.fsp_cfg = ddr_fsp0_2d_cfg,
 		.fsp_cfg_num = ARRAY_SIZE(ddr_fsp0_2d_cfg),
 	},
-
 };
-
 
 /* ddr timing config params */
 struct dram_timing_info dram_timing = {


### PR DESCRIPTION
Update according to Config Tools for i.MX 16.1 (v3.4.0_8.3-e3369a1a)

After generating the file, run:
    $ sha256sum lpddr4x_timing.c
    01efcffff1080ac54d57cad3fd82cbbc8ead24b7a35e8a77a9697e7f3e9afffa  lpddr4x_timing.c
    $ cp lpddr4x_timing.c ../uboot-imx/board/variscite/imx93_var_som/lpddr4x_timing.c
    $ cd ../uboot-imx
    $ sed -i 's/\r//g' board/variscite/imx93_var_som/lpddr4x_timing.c
    $ sed -i 's/    /\t/g' board/variscite/imx93_var_som/lpddr4x_timing.c

Signed-off-by: Nate Drude <nate.d@variscite.com>
(cherry picked from commit 9c734e92cdc91ff31e633db814b00eeaa58cf84d)