### PR TITLE
Develop imx v2017.03 4.9.11 1.0.0 ga var01 new wifi dorta

### DIFF
--- a/board/variscite/mx6ul_var_dart/mx6ul_var_dart.c
+++ b/board/variscite/mx6ul_var_dart/mx6ul_var_dart.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2015 Freescale Semiconductor, Inc.
  *
- * Copyright (C) 2015-2017 Variscite Ltd.
+ * Copyright (C) 2015-2024 Variscite Ltd.
  *
  * SPDX-License-Identifier:	GPL-2.0+
  */

--- a/board/variscite/mx6ul_var_dart/mx6ul_var_dart.c
+++ b/board/variscite/mx6ul_var_dart/mx6ul_var_dart.c
@@ -903,6 +903,12 @@ int board_late_init(void)
 	case 0x1:
 		setenv("som_rev", "5G"); /* Rev 2.x */
 		break;
+	case 0x2:
+		setenv("som_rev", "5G IW611");
+		break;
+	case 0x3:
+		setenv("som_rev", "5G IW612");
+		break;
 	default:
 		setenv("som_rev", "unknown");
 		break;

--- a/board/variscite/mx6ul_var_dart/mx6var_eeprom_v2.c
+++ b/board/variscite/mx6ul_var_dart/mx6var_eeprom_v2.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2017 Variscite Ltd.
+ * Copyright (C) 2015-2024 Variscite Ltd.
  *
  * Setup DRAM parameters and calibration values
  * for the specific DRAM on the board.

--- a/board/variscite/mx6ul_var_dart/mx6var_eeprom_v2.c
+++ b/board/variscite/mx6ul_var_dart/mx6var_eeprom_v2.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2015-2017 Variscite Ltd.
  *
- * Setup DRAM parametes and calibration values
+ * Setup DRAM parameters and calibration values
  * for the specific DRAM on the board.
  * The parameters were provided by
  * i.MX6 DDR Stress Test Tool and saved on EEPROM.
@@ -227,7 +227,7 @@ void var_eeprom_v2_print_som_info(const struct var_eeprom_v2_cfg *p_var_eeprom_v
 		puts("eMMC ");
 		break;
 	case 0x03:
-		puts("Ilegal !!! ");
+		puts("Illegal! ");
 		break;
 	}
 	if (p_var_eeprom_v2_cfg->som_info & 0x04)
@@ -319,7 +319,7 @@ static int do_var_eeprom_params(cmd_tbl_t *cmdtp, int flag, int argc, char * con
 		puts("eMMC");
 		break;
 	case 0x03:
-		puts("Ilegal!");
+		puts("Illegal!");
 		break;
 	}
 
@@ -340,7 +340,7 @@ static int do_var_eeprom_params(cmd_tbl_t *cmdtp, int flag, int argc, char * con
 		puts(", SOM Rev 2 (5G) (IW612)\n");
 		break;
 	default:
-		puts(", SOM Rev ilegal!\n");
+		puts(", SOM Rev illegal!\n");
 		break;
 	}
 

--- a/board/variscite/mx6ul_var_dart/mx6var_eeprom_v2.c
+++ b/board/variscite/mx6ul_var_dart/mx6var_eeprom_v2.c
@@ -232,8 +232,21 @@ void var_eeprom_v2_print_som_info(const struct var_eeprom_v2_cfg *p_var_eeprom_v
 	}
 	if (p_var_eeprom_v2_cfg->som_info & 0x04)
 		puts("WiFi");
-	if (((p_var_eeprom_v2_cfg->som_info >> 3) & 0x3) == 1)
-		puts(" (5G)");
+
+	switch ((p_var_eeprom_v2_cfg->som_info >> 3) & 0x3) {
+	case 0x0:
+		break;
+	case 0x1:
+		puts(" 5G");
+		break;
+	case 0x2:
+		puts(" 5G (IW611)");
+		break;
+	case 0x3:
+		puts(" 5G (IW612)");
+		break;
+	}
+
 	puts("\n");
 }
 #else
@@ -319,6 +332,12 @@ static int do_var_eeprom_params(cmd_tbl_t *cmdtp, int flag, int argc, char * con
 		break;
 	case 0x1:
 		puts(", SOM Rev 2 (5G)\n");
+		break;
+	case 0x2:
+		puts(", SOM Rev 2 (5G) (IW611)\n");
+		break;
+	case 0x3:
+		puts(", SOM Rev 2 (5G) (IW612)\n");
 		break;
 	default:
 		puts(", SOM Rev ilegal!\n");

--- a/board/variscite/mx6ul_var_dart/mx6var_eeprom_v2.h
+++ b/board/variscite/mx6ul_var_dart/mx6var_eeprom_v2.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2017 Variscite Ltd.
+ * Copyright (C) 2015-2024 Variscite Ltd.
  *
  * SPDX-License-Identifier: GPL-2.0+
  */

--- a/board/variscite/mx6ul_var_dart/mx6var_eeprom_v2.h
+++ b/board/variscite/mx6ul_var_dart/mx6var_eeprom_v2.h
@@ -35,9 +35,15 @@
 #define eeprom_v2_debug(M, ...)
 #endif
 
+/*
+ * EEPROM command structure (2 bytes per command). This structure holds
+ * an index into the address and value tables for EEPROM commands.
+ */
 struct __attribute__((packed)) eeprom_command
 {
+	/* 00-0x00: Index into the address table (1 byte) */
 	u8 address_index;
+	/* 01-0x01: Index into the value table (1 byte) */
 	u8 value_index;
 };
 
@@ -64,17 +70,27 @@ struct __attribute__((packed)) eeprom_command
  */
 struct __attribute__((packed)) var_eeprom_v2_cfg
 {
-	u32 variscite_magic; /* == HEX("VAR2")? */
+	/* 00-0x00: EEPROM Magic number (4 bytes) == HEX("VAR2")? */
+	u32 variscite_magic;
+	/* 04-0x04: Part number string (16 bytes) */
 	u8 part_number[16];
+	/* 20-0x14: Assembly number string (16 bytes) */
 	u8 assembly[16];
+	/* 36-0x24: Build date string (12 bytes) */
 	u8 date[12];
-	/* Contains addresses and values not present in .inc files */
+	/* 48-0x30: Custom addresses/values (128 bytes)
+	 * Contains addresses and values not present in .inc files
+	 */
 	u32 custom_addresses_values[32];
+	/* 176-0xB0: EEPROM commands array (300 bytes) */
 	struct eeprom_command commands[MAX_NUM_OF_COMMANDS];
+	/* 476-0x1DC: Reserved space for future use (33 bytes) */
 	u8 reserved[33];
+	/* 509-0x1FD: SOM information (1 byte) */
 	u8 som_info;
-	/* DRAM size in 128MiB unit */
+	/* 510-0x1FE: DRAM size in 128MiB units (1 byte) */
 	u8 dram_size;
+	/* 511-0x1FF: CRC for data integrity (1 byte) */
 	u8 crc;
 };
 

--- a/board/variscite/mx6ul_var_dart/mx6var_eeprom_v2.h
+++ b/board/variscite/mx6ul_var_dart/mx6var_eeprom_v2.h
@@ -41,6 +41,27 @@ struct __attribute__((packed)) eeprom_command
 	u8 value_index;
 };
 
+/*
+ * EEPROM SOM Info Bits Description
+ *
+ * Bit(s)   Description
+ * ------------------------------------------------------------------------
+ * 0-1      Storage Type
+ *              00 = SD card only
+ *              01 = NAND flash
+ *              10 = eMMC
+ *              11 = Illegal
+ *
+ * 2        Wi-Fi
+ *              0 = No Wi-Fi
+ *              1 = Wi-Fi
+ *
+ * 3-4      SOM Revision / Configuration
+ *              00 = DART-6UL
+ *              01 = DART-6UL-5G
+ *              10 = DART-6UL-5G (IW611)
+ *              11 = DART-6UL-5G (IW612)
+ */
 struct __attribute__((packed)) var_eeprom_v2_cfg
 {
 	u32 variscite_magic; /* == HEX("VAR2")? */

--- a/include/configs/mx6ul_var_dart.h
+++ b/include/configs/mx6ul_var_dart.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2015 Freescale Semiconductor, Inc.
  *
- * Copyright (C) 2015-2017 Variscite Ltd.
+ * Copyright (C) 2015-2024 Variscite Ltd.
  *
  * Configuration settings for Variscite i.MX6UL/L DART-6UL board family.
  *


### PR DESCRIPTION
Hey @eranmati, @nsdrude,

Could you please review this PR? I reviewed, and the patches are aligned with the Kirkstone and also working fine for all the SoMs that I have here:


```
U-Boot SPL 2017.03-mx6ul-jig+gd5d8202 (Nov 21 2024 - 13:31:50)

Part number: VSM-6UL-D06
Assembly: AS404216896
Date of production: 2024 Jul 03
SOM configuration: eMMC WiFi 5G (IW611)
Trying to boot from MMC1
MMC Boot Device: mmc0 (SD)


U-Boot 2017.03-mx6ul-jig+gd5d8202 (Nov 21 2024 - 13:31:50 +0000)

CPU:   Freescale i.MX6ULL rev1.1 900 MHz (running at 396 MHz)
CPU:   Commercial temperature grade (0C to 95C) at 41C
Reset cause: POR
Board: Variscite DART-6UL
I2C:   ready
DRAM:  512 MiB
MMC:   FSL_SDHC: 0, FSL_SDHC: 1
*** Warning - bad CRC, using default environment

In:    serial
Out:   serial
Err:   serial
switch to partitions #0, OK
mmc0 is current device
eMMC:  7.3 GiB
Net:   got MAC0 address from fuse: f8:dc:7a:da:56:ac
FEC0 [PRIME], usb_ether
Error: usb_ether address not set.

Normal Boot
=> 
```

Thanks,
Diego