### PR TITLE
imx95_var_dart: Add DRAM size variants

### DIFF
--- a/board/variscite/imx95_var_dart/Kconfig
+++ b/board/variscite/imx95_var_dart/Kconfig
@@ -9,4 +9,24 @@ config SYS_VENDOR
 config SYS_CONFIG_NAME
 	default "imx95_var_dart"
 
+choice
+	prompt "DART-MX95 DRAM size"
+	default IMX95_VAR_DART_8GB
+	help
+	  Select the DRAM size for the DART-MX95.
+
+config IMX95_VAR_DART_2GB
+	bool "2GB"
+
+config IMX95_VAR_DART_4GB
+	bool "4GB"
+
+config IMX95_VAR_DART_8GB
+	bool "8GB"
+
+config IMX95_VAR_DART_16GB
+	bool "16GB"
+
+endchoice
+
 endif

--- a/include/configs/imx95_var_dart.h
+++ b/include/configs/imx95_var_dart.h
@@ -252,9 +252,23 @@
 
 #define CFG_SYS_SDRAM_BASE           0x90000000
 #define PHYS_SDRAM                      0x90000000
+#if defined(CONFIG_IMX95_VAR_DART_16GB)
+/* Totally 16GB */
+#define PHYS_SDRAM_SIZE			0x70000000UL /* 2GB  - 256MB DDR */
+#define PHYS_SDRAM_2_SIZE 		0x380000000 /* 14GB */
+#elif defined(CONFIG_IMX95_VAR_DART_2GB)
+/* Totally 2GB */
+#define PHYS_SDRAM_SIZE			0x70000000UL /* 2GB  - 256MB DDR */
+#define PHYS_SDRAM_2_SIZE 		0x0 /* 0GB */
+#elif defined(CONFIG_IMX95_VAR_DART_4GB)
+/* Totally 4GB */
+#define PHYS_SDRAM_SIZE			0x70000000UL /* 2GB  - 256MB DDR */
+#define PHYS_SDRAM_2_SIZE 		0x80000000 /* 2GB */
+#else
 /* Totally 8GB */
 #define PHYS_SDRAM_SIZE			0x70000000UL /* 2GB  - 256MB DDR */
 #define PHYS_SDRAM_2_SIZE 		0x180000000 /* 6GB */
+#endif
 
 #define DEFAULT_SDRAM_SIZE		(4UL * SZ_1G) /* 4GB Minimum DDR5, see get_dram_size */
 #define VAR_EEPROM_DRAM_START	(PHYS_SDRAM + (DEFAULT_SDRAM_SIZE >> 1))


### PR DESCRIPTION
This will add DART-MX95 DRAM size variant support setting the DRAM size accordingly.

For the time being, 2, 4, 8 and 16GB are supported. The choice defaults to 8GB DRAM size.